### PR TITLE
fix(iOS): use install_modules_dependencies for New Architecture compatibility

### DIFF
--- a/reteno-react-native-sdk.podspec
+++ b/reteno-react-native-sdk.podspec
@@ -1,7 +1,6 @@
 require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
-folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
   s.name         = "reteno-react-native-sdk"
@@ -16,21 +15,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency 'React-Core'
   s.dependency 'Reteno', '2.5.13'
 
-  # Don't install the dependencies when we run `pod install` in the old architecture.
-  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-        "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-        "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-        "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-    }
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
-  end
+  install_modules_dependencies(s)
 end


### PR DESCRIPTION
## Description

Replaces the legacy manual New Architecture dependency configuration in the podspec with the `install_modules_dependencies(s)` helper provided by React Native.

## Problem

The current podspec uses the old `RCT_NEW_ARCH_ENABLED` env variable pattern with manual dependencies (`React-Codegen`, `RCT-Folly`, `RCTRequired`, `RCTTypeSafety`, `ReactCommon/turbomodule/core`). This approach was deprecated in React Native 0.71 and causes `pod install` failures with React Native 0.73+ in New Architecture mode.

## Fix

Replace the entire `if ENV['RCT_NEW_ARCH_ENABLED']` block (and the unused `folly_compiler_flags` variable) with a single call to `install_modules_dependencies(s)`, which is the official recommended helper since RN 0.71. It handles dependency resolution correctly for both old and new architecture automatically.

```diff
-folly_compiler_flags = '-DFOLLY_NO_CONFIG ...'
-
-  s.dependency 'React-Core'
   s.dependency 'Reteno', '2.5.13'
 
-  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig = { ... }
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
-  end
+  install_modules_dependencies(s)
```

## References

- [React Native New Architecture setup guide](https://reactnative.dev/docs/new-architecture-library-intro#preparing-your-podspec)