### PR TITLE
V2.2.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -72,7 +72,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'com.reteno:fcm:2.9.6'
+  implementation 'com.reteno:fcm:2.10.1'
   implementation "com.google.firebase:firebase-messaging:23.1.0"
   implementation "com.google.firebase:firebase-messaging-ktx:23.1.0"
   coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.2'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -75,7 +75,7 @@ dependencies {
   implementation 'com.reteno:fcm:2.10.1'
   implementation "com.google.firebase:firebase-messaging:23.1.0"
   implementation "com.google.firebase:firebase-messaging-ktx:23.1.0"
-  coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.2'
+  coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
   xmlns:tools="http://schemas.android.com/tools"
   package="com.retenosdk">
   <application>
+    <provider
+      android:name="com.retenosdk.RetenoNotificationGroupingRuleProvider"
+      android:authorities="${applicationId}.reteno.notification-grouping-rule"
+      android:exported="false" />
     <service
       android:name="com.retenosdk.RetenoMessagingService"
       android:exported="false">

--- a/android/src/main/java/com/retenosdk/RetenoNotificationGroupingRuleProvider.java
+++ b/android/src/main/java/com/retenosdk/RetenoNotificationGroupingRuleProvider.java
@@ -46,6 +46,18 @@ public final class RetenoNotificationGroupingRuleProvider extends ContentProvide
     );
   }
 
+  /** Resolves the group a received push belongs to under the currently configured rule, or null if none applies. */
+  public static String resolveGroup(Context context, Map<String, String> payload) {
+    SharedPreferences preferences = preferences(context);
+    String payloadKey = preferences.getString(PAYLOAD_KEY, null);
+    if (!TextUtils.isEmpty(payloadKey)) {
+      String value = payload.get(payloadKey);
+      return TextUtils.isEmpty(value) ? null : value;
+    }
+    String groupId = preferences.getString(GROUP_ID, null);
+    return TextUtils.isEmpty(groupId) ? null : groupId;
+  }
+
   private static SharedPreferences preferences(Context context) {
     return context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE);
   }

--- a/android/src/main/java/com/retenosdk/RetenoNotificationGroupingRuleProvider.java
+++ b/android/src/main/java/com/retenosdk/RetenoNotificationGroupingRuleProvider.java
@@ -1,0 +1,90 @@
+package com.retenosdk;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.database.Cursor;
+import android.net.Uri;
+import android.text.TextUtils;
+
+import com.reteno.push.RetenoNotifications;
+
+import java.util.Map;
+
+/** Restores notification grouping before React Native and push services start. */
+public final class RetenoNotificationGroupingRuleProvider extends ContentProvider {
+  private static final String PREFERENCES = "com.retenosdk.notification-grouping-rule";
+  private static final String PAYLOAD_KEY = "payloadKey";
+  private static final String GROUP_ID = "groupId";
+
+  @Override
+  public boolean onCreate() {
+    Context context = getContext();
+    if (context != null) {
+      restore(context);
+    }
+    return true;
+  }
+
+  static void configure(Context context, String payloadKey, String groupId) {
+    SharedPreferences.Editor editor = preferences(context).edit().clear();
+    if (!TextUtils.isEmpty(payloadKey)) {
+      editor.putString(PAYLOAD_KEY, payloadKey);
+    } else if (!TextUtils.isEmpty(groupId)) {
+      editor.putString(GROUP_ID, groupId);
+    }
+    editor.commit();
+    install(payloadKey, groupId);
+  }
+
+  private static void restore(Context context) {
+    SharedPreferences preferences = preferences(context);
+    install(
+      preferences.getString(PAYLOAD_KEY, null),
+      preferences.getString(GROUP_ID, null)
+    );
+  }
+
+  private static SharedPreferences preferences(Context context) {
+    return context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE);
+  }
+
+  private static void install(String payloadKey, String groupId) {
+    if (!TextUtils.isEmpty(payloadKey)) {
+      RetenoNotifications.setGroupingRule((Map<String, String> payload) -> {
+        String value = payload.get(payloadKey);
+        return TextUtils.isEmpty(value) ? null : value;
+      });
+    } else if (!TextUtils.isEmpty(groupId)) {
+      RetenoNotifications.setGroupingRule((Map<String, String> payload) -> groupId);
+    } else {
+      RetenoNotifications.setGroupingRule(null);
+    }
+  }
+
+  @Override
+  public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
+    return null;
+  }
+
+  @Override
+  public String getType(Uri uri) {
+    return null;
+  }
+
+  @Override
+  public Uri insert(Uri uri, ContentValues values) {
+    return null;
+  }
+
+  @Override
+  public int delete(Uri uri, String selection, String[] selectionArgs) {
+    return 0;
+  }
+
+  @Override
+  public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
+    return 0;
+  }
+}

--- a/android/src/main/java/com/retenosdk/RetenoPushReceiver.java
+++ b/android/src/main/java/com/retenosdk/RetenoPushReceiver.java
@@ -3,10 +3,18 @@ package com.retenosdk;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Bundle;
+
+import com.reteno.push.events.NotificationReceived;
 
 public class RetenoPushReceiver extends BroadcastReceiver {
   @Override
   public void onReceive(Context context, Intent intent) {
     RetenoSdkModule.onRetenoPushReceived(context, intent);
+    // This receiver replaces the native SDK's own PushReceivedReceiver (via the
+    // com.reteno.Receiver.PushReceived meta-data override), so RetenoNotifications.received
+    // would otherwise never fire in a React Native app. Re-dispatch it manually.
+    Bundle extras = intent.getExtras();
+    NotificationReceived.INSTANCE.notifyListeners(extras != null ? extras : new Bundle());
   }
 }

--- a/android/src/main/java/com/retenosdk/RetenoSdkModule.java
+++ b/android/src/main/java/com/retenosdk/RetenoSdkModule.java
@@ -1134,6 +1134,41 @@ public void logEcomEventSearchRequest(ReadableMap payload, Promise promise) {
   }
 
   @ReactMethod
+  public void setNotificationGroupingRule(@Nullable ReadableMap rule, Promise promise) {
+    if (rule == null) {
+      RetenoNotificationGroupingRuleProvider.configure(context, null, null);
+      promise.resolve(true);
+      return;
+    }
+
+    boolean payloadKeyIsString = rule.hasKey("payloadKey")
+      && !rule.isNull("payloadKey")
+      && rule.getType("payloadKey") == ReadableType.String;
+    boolean groupIdIsString = rule.hasKey("groupId")
+      && !rule.isNull("groupId")
+      && rule.getType("groupId") == ReadableType.String;
+    String payloadKey = payloadKeyIsString ? rule.getString("payloadKey").trim() : null;
+    String groupId = groupIdIsString ? rule.getString("groupId").trim() : null;
+    boolean hasPayloadKey = payloadKey != null && !payloadKey.isEmpty();
+    boolean hasGroupId = groupId != null && !groupId.isEmpty();
+
+    if (hasPayloadKey == hasGroupId) {
+      promise.reject(
+        "InvalidArgument",
+        "Invalid argument: provide exactly one non-empty payloadKey or groupId"
+      );
+      return;
+    }
+
+    RetenoNotificationGroupingRuleProvider.configure(
+      context,
+      hasPayloadKey ? payloadKey : null,
+      hasGroupId ? groupId : null
+    );
+    promise.resolve(true);
+  }
+
+  @ReactMethod
   public void pausePushInAppMessages(Boolean isPaused, Promise promise) {
     try {
       getRetenoInstance()

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -89,7 +89,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "1.7.15"
+        versionName "1.7.16"
     }
 
     signingConfigs {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -89,7 +89,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "1.7.16"
+        versionName "1.7.17"
     }
 
     signingConfigs {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -126,7 +126,7 @@ dependencies {
     implementation("com.facebook.react:react-android")
     // implementation("com.facebook.react:flipper-integration")
 
-    implementation 'com.reteno:fcm:2.9.6'
+    implementation 'com.reteno:fcm:2.10.1'
     implementation "com.google.firebase:firebase-messaging:23.1.0"
     implementation "com.google.firebase:firebase-messaging-ktx:23.1.0"
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -136,5 +136,5 @@ dependencies {
         implementation jscFlavor
     }
 
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.2'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -89,7 +89,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "1.7.17"
+        versionName "1.7.18"
     }
 
     signingConfigs {

--- a/example/android/app/src/main/java/com/reteno/sample/MainApplication.kt
+++ b/example/android/app/src/main/java/com/reteno/sample/MainApplication.kt
@@ -1,6 +1,16 @@
 package com.reteno.sample
 
+import android.Manifest
 import android.app.Application
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import androidx.core.app.ActivityCompat
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import com.facebook.react.PackageList
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactHost
@@ -8,8 +18,22 @@ import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 import com.facebook.soloader.SoLoader
 import com.facebook.react.soloader.OpenSourceMergedSoMapping
+import com.reteno.push.RetenoNotifications
+import com.retenosdk.RetenoNotificationGroupingRuleProvider
 
 class MainApplication : Application(), ReactApplication {
+
+  companion object {
+    private const val SUMMARY_CHANNEL_ID = "reteno_demo_group_summary"
+
+    // The "received" event is broadcast on the main thread while the SDK posts the push's own
+    // notification on a background thread — there's no ordering guarantee between the two, and
+    // posting can take longer than usual (e.g. downloading a BigPictureStyle image). A fixed
+    // delay is a heuristic, not a guarantee: if posting is slower than this, the summary is
+    // simply skipped for this push and shown on the next one instead of undercounting silently.
+    // Good enough for a demo; a production integration should not rely on a fixed delay.
+    private const val SUMMARY_CHECK_DELAY_MS = 500L
+  }
 
   override val reactHost: ReactHost by lazy {
     getDefaultReactHost(
@@ -24,5 +48,52 @@ class MainApplication : Application(), ReactApplication {
     if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
       loadReactNative(this)
     }
+    createSummaryNotificationChannel()
+    RetenoNotifications.received.addListener { bundle -> onPushReceivedForGrouping(bundle) }
+  }
+
+  private fun createSummaryNotificationChannel() {
+    val channel = NotificationChannel(
+      SUMMARY_CHANNEL_ID,
+      "Grouped notifications summary",
+      NotificationManager.IMPORTANCE_DEFAULT
+    )
+    NotificationManagerCompat.from(this).createNotificationChannel(channel)
+  }
+
+  private fun onPushReceivedForGrouping(bundle: Bundle) {
+    val payload = bundle.keySet().associateWith { bundle.getString(it) }
+    val group = RetenoNotificationGroupingRuleProvider.resolveGroup(this, payload) ?: return
+    Handler(Looper.getMainLooper()).postDelayed(
+      { showGroupSummaryNotification(group) },
+      SUMMARY_CHECK_DELAY_MS
+    )
+  }
+
+  private fun showGroupSummaryNotification(group: String) {
+    val manager = NotificationManagerCompat.from(this)
+    val groupedCount = manager.activeNotifications.count {
+      it.notification.group == group && !NotificationCompat.isGroupSummary(it.notification)
+    }
+    if (groupedCount < 2) return
+
+    if (ActivityCompat.checkSelfPermission(
+        this,
+        Manifest.permission.POST_NOTIFICATIONS
+      ) != PackageManager.PERMISSION_GRANTED
+    ) return
+
+    val summary = NotificationCompat.Builder(this, SUMMARY_CHANNEL_ID)
+      .setContentTitle("New notifications")
+      .setContentText("You have $groupedCount new notifications")
+      .setSmallIcon(R.mipmap.ic_launcher)
+      .setGroup(group)
+      .setGroupSummary(true)
+      .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)
+      .setOnlyAlertOnce(true)
+      .setAutoCancel(true)
+      .build()
+
+    manager.notify(group.hashCode(), summary)
   }
 }

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -27,7 +27,7 @@ end
 
 target 'RetenoSdkExample' do
   config = use_native_modules!
-  pod 'Reteno', '2.7.2'
+  pod 'Reteno', '2.7.3'
 
   use_frameworks! :linkage => :static
   $RNFirebaseAsStaticFramework = true
@@ -39,7 +39,7 @@ target 'RetenoSdkExample' do
 
   target 'NotificationServiceExtension' do
     inherit! :search_paths
-    pod 'Reteno', '2.7.2'
+    pod 'Reteno', '2.7.3'
   end
 
   target 'RetenoSdkExampleTests' do

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2599,7 +2599,7 @@ PODS:
     - React-utils (= 0.83.0)
     - SocketRocket
   - Reteno (2.7.3)
-  - reteno-react-native-sdk (2.1.1):
+  - reteno-react-native-sdk (2.2.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3056,7 +3056,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 0c8601ce03eb3f724f4d251e4aa158555bf20942
   ReactCommon: 913c93ca20654c90cc57a3dd9e291b4ef9956e54
   Reteno: 68363208d2074b359a95516f11391499121718c3
-  reteno-react-native-sdk: 1dd788e65a55d282817951f7817158ff6c987eaf
+  reteno-react-native-sdk: 9427080f530254b3d6bec335bfa81e032d0a1fdc
   RNFBApp: 3cbad248e866e6c5d753612446ffc48f6ac3be3a
   RNFBMessaging: 7d5016a17a2e62e66b3c92ffdf4851249c06e9c0
   RNScreens: e902eba58a27d3ad399a495d578e8aba3ea0f490

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2598,7 +2598,7 @@ PODS:
     - React-perflogger (= 0.83.0)
     - React-utils (= 0.83.0)
     - SocketRocket
-  - Reteno (2.7.2)
+  - Reteno (2.7.3)
   - reteno-react-native-sdk (2.1.1):
     - boost
     - DoubleConversion
@@ -2625,7 +2625,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - Reteno (= 2.7.2)
+    - Reteno (= 2.7.3)
     - SocketRocket
     - Yoga
   - RNFBApp (19.3.0):
@@ -2777,7 +2777,7 @@ DEPENDENCIES:
   - ReactAppDependencyProvider (from `build/generated/ios/ReactAppDependencyProvider`)
   - ReactCodegen (from `build/generated/ios/ReactCodegen`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
-  - Reteno (= 2.7.2)
+  - Reteno (= 2.7.3)
   - reteno-react-native-sdk (from `../..`)
   - "RNFBApp (from `../node_modules/@react-native-firebase/app`)"
   - "RNFBMessaging (from `../node_modules/@react-native-firebase/messaging`)"
@@ -3055,14 +3055,14 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: ebcf3a78dc1bcdf054c9e8d309244bade6b31568
   ReactCodegen: 0c8601ce03eb3f724f4d251e4aa158555bf20942
   ReactCommon: 913c93ca20654c90cc57a3dd9e291b4ef9956e54
-  Reteno: 2634f80dcaa740a31558444e2623901a88a5585a
-  reteno-react-native-sdk: 0f42ef8f7b87726cd15b1e954760d5edcdfb7cb6
+  Reteno: 68363208d2074b359a95516f11391499121718c3
+  reteno-react-native-sdk: 1dd788e65a55d282817951f7817158ff6c987eaf
   RNFBApp: 3cbad248e866e6c5d753612446ffc48f6ac3be3a
   RNFBMessaging: 7d5016a17a2e62e66b3c92ffdf4851249c06e9c0
   RNScreens: e902eba58a27d3ad399a495d578e8aba3ea0f490
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: faec420ba5f8a2bd196f26048a0557882d40e5b9
 
-PODFILE CHECKSUM: bd5589028059f13bc7afbfe52fac1363a50e21f2
+PODFILE CHECKSUM: 2803e060b58881b08f1c14bd6341b9100ece3af7
 
 COCOAPODS: 1.16.2

--- a/example/ios/RetenoSdkExample.xcodeproj/project.pbxproj
+++ b/example/ios/RetenoSdkExample.xcodeproj/project.pbxproj
@@ -657,7 +657,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 572;
+				CURRENT_PROJECT_VERSION = 577;
 				DEFINES_MODULE = NO;
 				DEVELOPMENT_TEAM = X9JJR3XKX7;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = X9JJR3XKX7;
@@ -696,7 +696,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 572;
+				CURRENT_PROJECT_VERSION = 577;
 				DEFINES_MODULE = NO;
 				DEVELOPMENT_TEAM = X9JJR3XKX7;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = X9JJR3XKX7;

--- a/example/ios/fastlane/report.xml
+++ b/example/ios/fastlane/report.xml
@@ -5,62 +5,62 @@
     
     
       
-      <testcase classname="fastlane.lanes" name="00: default_platform" time="0.000322">
+      <testcase classname="fastlane.lanes" name="00: default_platform" time="0.000191">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="01: ci_setup" time="0.00052">
+      <testcase classname="fastlane.lanes" name="01: ci_setup" time="0.000402">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="02: app_store_connect_api_key_set_from_remote" time="3.10187">
+      <testcase classname="fastlane.lanes" name="02: app_store_connect_api_key_set_from_remote" time="2.075224">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="03: Switch to ios archive lane" time="0.000185">
+      <testcase classname="fastlane.lanes" name="03: Switch to ios archive lane" time="0.00019">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="04: Switch to ios sync_certs lane" time="7.5e-05">
+      <testcase classname="fastlane.lanes" name="04: Switch to ios sync_certs lane" time="9.8e-05">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="05: match" time="1.319023">
+      <testcase classname="fastlane.lanes" name="05: match" time="1.117926">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="06: update_code_signing_settings" time="0.036692">
+      <testcase classname="fastlane.lanes" name="06: update_code_signing_settings" time="0.054119">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="07: update_code_signing_settings" time="0.01031">
+      <testcase classname="fastlane.lanes" name="07: update_code_signing_settings" time="0.01143">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="08: update_code_signing_settings" time="0.012593">
+      <testcase classname="fastlane.lanes" name="08: update_code_signing_settings" time="0.011094">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="09: build_app" time="216.13109">
+      <testcase classname="fastlane.lanes" name="09: build_app" time="235.540658">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="10: upload_to_testflight" time="213.154279">
+      <testcase classname="fastlane.lanes" name="10: upload_to_testflight" time="210.279243">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="11: ci_teardown" time="0.000519">
+      <testcase classname="fastlane.lanes" name="11: ci_teardown" time="0.000293">
         
       </testcase>
     

--- a/example/src/screens/pushNotifications.tsx
+++ b/example/src/screens/pushNotifications.tsx
@@ -15,8 +15,9 @@ import {
   pausePushInAppMessages,
   setPushInAppMessagesPauseBehaviour,
   registerForRemoteNotifications,
+  setNotificationGroupingRule,
 } from 'reteno-react-native-sdk';
-import type { InAppPauseBehaviour } from 'reteno-react-native-sdk';
+import type { InAppPauseBehaviour, NotificationGroupingRule } from 'reteno-react-native-sdk';
 import { Button } from '../components/Button';
 import styles from './styles';
 
@@ -120,6 +121,12 @@ export default function PushNotificationsScreen() {
       .catch(error => Alert.alert('Error', String(error)));
   };
 
+  const handleSetNotificationGroupingRule = (rule: NotificationGroupingRule | null) => {
+    setNotificationGroupingRule(rule)
+      .then(() => Alert.alert('Success', `Notification grouping rule: ${rule ? JSON.stringify(rule) : 'disabled'}`))
+      .catch(error => Alert.alert('Error', String(error)));
+  };
+
   return (
     <SafeAreaView style={styles.container}>
       <ScrollView>
@@ -167,6 +174,21 @@ export default function PushNotificationsScreen() {
             onPress={() => handleSetPushInAppMessagesPauseBehaviour('POSTPONE_IN_APPS')}
             label="Push-triggered in-app behaviour: Postpone"
           />
+        )}
+        {Platform.OS === 'android' && (
+          <Button
+            onPress={() => handleSetNotificationGroupingRule({ payloadKey: 'chatId' })}
+            label="Group notifications by payload key 'chatId'"
+          />
+        )}
+        {Platform.OS === 'android' && (
+          <Button
+            onPress={() => handleSetNotificationGroupingRule({ groupId: 'messages' })}
+            label="Group notifications under constant ID 'messages'"
+          />
+        )}
+        {Platform.OS === 'android' && (
+          <Button onPress={() => handleSetNotificationGroupingRule(null)} label="Disable notification grouping" />
         )}
         {Platform.OS === 'ios' && (
           <Button onPress={registerForRemoteNotifications} label="Register for Remote Notifications" />

--- a/ios/RetenoSdk.swift
+++ b/ios/RetenoSdk.swift
@@ -167,7 +167,7 @@ open class RetenoSdk: RCTEventEmitter {
             isAutomaticScreenReportingEnabled: false,
             isAutomaticAppLifecycleReportingEnabled: lifecycleAppEnabled,
             isApplicationForegroundLifecycleReportingEnabled: lifecycleForegroundEnabled,
-            isAutomaticPushSubsriptionReportingEnabled: lifecyclePushEnabled,
+            isAutomaticPushSubscriptionReportingEnabled: lifecyclePushEnabled,
             sessionConfiguration: RetenoSessionConfiguration(
                 sessionDuration: sessionDurationSeconds,
                 isSessionStartReportingEnabled: lifecycleSessionStartEnabled,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reteno-react-native-sdk",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "The Reteno React Native SDK for App Analytics and Engagement.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/reteno-react-native-sdk.podspec
+++ b/reteno-react-native-sdk.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency 'Reteno', '2.7.2'
+  s.dependency 'Reteno', '2.7.3'
 
   install_modules_dependencies(s)
 end

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,1 +1,71 @@
-it.todo('write a test');
+const mockSetNotificationGroupingRule = jest.fn(() => Promise.resolve());
+
+export {};
+
+jest.mock('react-native', () => ({
+  DeviceEventEmitter: { addListener: jest.fn() },
+  NativeEventEmitter: jest.fn(),
+  NativeModules: new Proxy(
+    {},
+    {
+      get: (_target, property) =>
+        property === 'RetenoSdk'
+          ? { setNotificationGroupingRule: mockSetNotificationGroupingRule }
+          : undefined,
+    }
+  ),
+  Platform: {
+    OS: 'android',
+    select: jest.fn(({ default: defaultValue }) => defaultValue),
+  },
+}));
+
+const { setNotificationGroupingRule } =
+  require('../index') as typeof import('../index');
+
+describe('setNotificationGroupingRule', () => {
+  beforeEach(() => {
+    mockSetNotificationGroupingRule.mockClear();
+  });
+
+  it('normalizes a payload key rule', async () => {
+    await setNotificationGroupingRule({ payloadKey: '  chatId  ' });
+
+    expect(mockSetNotificationGroupingRule).toHaveBeenCalledWith({
+      payloadKey: 'chatId',
+    });
+  });
+
+  it('normalizes a constant group id rule', async () => {
+    await setNotificationGroupingRule({ groupId: '  messages  ' });
+
+    expect(mockSetNotificationGroupingRule).toHaveBeenCalledWith({
+      groupId: 'messages',
+    });
+  });
+
+  it('passes null to disable grouping', async () => {
+    await setNotificationGroupingRule(null);
+
+    expect(mockSetNotificationGroupingRule).toHaveBeenCalledWith(null);
+  });
+
+  it('rejects an empty rule', async () => {
+    await expect(
+      setNotificationGroupingRule({ payloadKey: '  ' })
+    ).rejects.toThrow(
+      'Invalid argument: provide exactly one of payloadKey or groupId'
+    );
+  });
+
+  it('rejects a rule containing both modes', async () => {
+    await expect(
+      setNotificationGroupingRule({
+        payloadKey: 'chatId',
+        groupId: 'messages',
+      } as unknown as Parameters<typeof setNotificationGroupingRule>[0])
+    ).rejects.toThrow(
+      'Invalid argument: provide exactly one of payloadKey or groupId'
+    );
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,6 +145,14 @@ export type NotificationPermissionStatus =
   | 'DENIED'
   | 'PERMANENTLY_DENIED';
 
+/**
+ * Android notification grouping rule. The rule is stored natively and restored
+ * before React Native starts, so it is also applied to background notifications.
+ */
+export type NotificationGroupingRule =
+  | { payloadKey: string; groupId?: never }
+  | { groupId: string; payloadKey?: never };
+
 export type InAppCustomData = {
   customData?: Record<string, any>;
   inapp_id?: string;
@@ -878,6 +886,45 @@ export function getNotificationPermissionStatus(): Promise<NotificationPermissio
     return RetenoSdk.getNotificationPermissionStatus();
   }
   return Promise.resolve('ALLOWED' as NotificationPermissionStatus);
+}
+
+/**
+ * Android only. Groups notifications by a push payload value or a constant ID.
+ * Pass `null` to disable grouping.
+ */
+export function setNotificationGroupingRule(
+  rule: NotificationGroupingRule | null
+): Promise<void> {
+  if (Platform.OS !== 'android') {
+    return Promise.resolve(undefined);
+  }
+
+  if (rule === null) {
+    return RetenoSdk.setNotificationGroupingRule(null);
+  }
+
+  if (!rule || typeof rule !== 'object') {
+    return Promise.reject(
+      new Error(
+        'Invalid argument: expected null or an object with payloadKey or groupId'
+      )
+    );
+  }
+
+  const payloadKey =
+    typeof rule.payloadKey === 'string' ? rule.payloadKey.trim() : '';
+  const groupId = typeof rule.groupId === 'string' ? rule.groupId.trim() : '';
+  if (!!payloadKey === !!groupId) {
+    return Promise.reject(
+      new Error(
+        'Invalid argument: provide exactly one of payloadKey or groupId'
+      )
+    );
+  }
+
+  return RetenoSdk.setNotificationGroupingRule(
+    payloadKey ? { payloadKey } : { groupId }
+  );
 }
 
 /**


### PR DESCRIPTION
**Added**
- 🚀 Android notification grouping — `setNotificationGroupingRule({ payloadKey })` or `{ groupId })`. The rule is persisted natively and restored before the app starts, so it also applies to notifications received while the app isn't running. See README for grouping by payload value vs. a constant ID, and for adding a native summary notification.

**Fixed**
- 🐛 iOS: renamed `isAutomaticPushSubsriptionReportingEnabled` → `isAutomaticPushSubscriptionReportingEnabled` (typo fix, matches the upstream rename in Reteno iOS SDK 2.7.3).

**Dependencies**
- Reteno Android SDK → `2.10.1`
- Reteno iOS SDK → `2.7.3`