### PR TITLE
V2.3.0

### DIFF
--- a/android/src/main/java/com/retenosdk/RetenoClickReceiver.java
+++ b/android/src/main/java/com/retenosdk/RetenoClickReceiver.java
@@ -3,10 +3,18 @@ package com.retenosdk;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Bundle;
+
+import com.reteno.push.events.NotificationClick;
 
 public class RetenoClickReceiver extends BroadcastReceiver {
   @Override
   public void onReceive(Context context, Intent intent) {
+    Bundle extras = intent.getExtras();
+    // Registering this receiver in the manifest's NotificationClicked meta-data replaces
+    // Reteno's own click receiver, which is what normally drives NotificationClick listeners
+    // (e.g. RetenoNotificationSummaryManager). Notify it ourselves so those listeners still fire.
+    NotificationClick.INSTANCE.notifyListeners(extras != null ? extras : Bundle.EMPTY);
     RetenoSdkModule.onRetenoPushClicked(context, intent);
   }
 }

--- a/android/src/main/java/com/retenosdk/RetenoNotificationGroupingRuleProvider.java
+++ b/android/src/main/java/com/retenosdk/RetenoNotificationGroupingRuleProvider.java
@@ -17,6 +17,7 @@ public final class RetenoNotificationGroupingRuleProvider extends ContentProvide
   private static final String PREFERENCES = "com.retenosdk.notification-grouping-rule";
   private static final String PAYLOAD_KEY = "payloadKey";
   private static final String GROUP_ID = "groupId";
+  private static final String SHOW_SUMMARY = "showSummary";
 
   @Override
   public boolean onCreate() {
@@ -27,27 +28,33 @@ public final class RetenoNotificationGroupingRuleProvider extends ContentProvide
     return true;
   }
 
-  static void configure(Context context, String payloadKey, String groupId) {
+  static void configure(Context context, String payloadKey, String groupId, boolean showSummary) {
     SharedPreferences.Editor editor = preferences(context).edit().clear();
     if (!TextUtils.isEmpty(payloadKey)) {
       editor.putString(PAYLOAD_KEY, payloadKey);
     } else if (!TextUtils.isEmpty(groupId)) {
       editor.putString(GROUP_ID, groupId);
     }
+    if (showSummary) {
+      editor.putBoolean(SHOW_SUMMARY, true);
+    }
+    // Persist before returning so a process restart cannot lose a just-configured rule.
     editor.commit();
-    install(payloadKey, groupId);
+    install(context, payloadKey, groupId, showSummary);
   }
 
   private static void restore(Context context) {
     SharedPreferences preferences = preferences(context);
     install(
+      context,
       preferences.getString(PAYLOAD_KEY, null),
-      preferences.getString(GROUP_ID, null)
+      preferences.getString(GROUP_ID, null),
+      preferences.getBoolean(SHOW_SUMMARY, false)
     );
   }
 
-  /** Resolves the group a received push belongs to under the currently configured rule, or null if none applies. */
-  public static String resolveGroup(Context context, Map<String, String> payload) {
+  /** Resolves the group a received push belongs to under the persisted rule. */
+  static String resolveGroup(Context context, Map<String, String> payload) {
     SharedPreferences preferences = preferences(context);
     String payloadKey = preferences.getString(PAYLOAD_KEY, null);
     if (!TextUtils.isEmpty(payloadKey)) {
@@ -62,7 +69,7 @@ public final class RetenoNotificationGroupingRuleProvider extends ContentProvide
     return context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE);
   }
 
-  private static void install(String payloadKey, String groupId) {
+  private static void install(Context context, String payloadKey, String groupId, boolean showSummary) {
     if (!TextUtils.isEmpty(payloadKey)) {
       RetenoNotifications.setGroupingRule((Map<String, String> payload) -> {
         String value = payload.get(payloadKey);
@@ -73,6 +80,11 @@ public final class RetenoNotificationGroupingRuleProvider extends ContentProvide
     } else {
       RetenoNotifications.setGroupingRule(null);
     }
+    RetenoNotificationSummaryManager.setEnabled(
+      context,
+      showSummary && (!TextUtils.isEmpty(payloadKey) || !TextUtils.isEmpty(groupId)),
+      !TextUtils.isEmpty(payloadKey) ? "payloadKey:" + payloadKey : "groupId:" + groupId
+    );
   }
 
   @Override

--- a/android/src/main/java/com/retenosdk/RetenoNotificationSummaryManager.java
+++ b/android/src/main/java/com/retenosdk/RetenoNotificationSummaryManager.java
@@ -1,0 +1,273 @@
+package com.retenosdk;
+
+import android.Manifest;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.service.notification.StatusBarNotification;
+
+import androidx.core.app.ActivityCompat;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
+
+import com.reteno.core.util.Procedure;
+import com.reteno.push.RetenoNotifications;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/** Maintains optional Android group-summary notifications for Reteno pushes. */
+final class RetenoNotificationSummaryManager {
+  private static final String SUMMARY_CHANNEL_ID = "reteno_group_summary";
+  private static final String SUMMARY_TAG_PREFIX = "com.retenosdk.group-summary:";
+  private static final int SUMMARY_NOTIFICATION_ID = 1;
+  private static final int MAX_POST_ATTEMPTS = 25;
+  private static final int MAX_REMOVAL_ATTEMPTS = 10;
+  private static final long RETRY_DELAY_MS = 200L;
+
+  private static RetenoNotificationSummaryManager instance;
+
+  private final Context context;
+  private final Handler mainHandler = new Handler(Looper.getMainLooper());
+  private final Handler retryHandler = new Handler(Looper.getMainLooper());
+  private final NotificationManagerCompat notificationManager;
+
+  private Procedure<Bundle> receivedListener;
+  private Procedure<Bundle> clickListener;
+  private Procedure<Bundle> closeListener;
+  private boolean enabled;
+  private String ruleIdentity;
+
+  private RetenoNotificationSummaryManager(Context context) {
+    this.context = context.getApplicationContext();
+    this.notificationManager = NotificationManagerCompat.from(this.context);
+  }
+
+  static synchronized void setEnabled(Context context, boolean enabled, String ruleIdentity) {
+    if (instance == null) {
+      instance = new RetenoNotificationSummaryManager(context);
+    }
+    instance.runOnMainThread(() -> instance.updateEnabled(enabled, ruleIdentity));
+  }
+
+  private void runOnMainThread(Runnable action) {
+    if (Looper.myLooper() == Looper.getMainLooper()) {
+      action.run();
+    } else {
+      mainHandler.post(action);
+    }
+  }
+
+  private void updateEnabled(boolean shouldEnable, String ruleIdentity) {
+    if (shouldEnable) {
+      enable(ruleIdentity);
+    } else {
+      disable();
+    }
+  }
+
+  private void enable(String ruleIdentity) {
+    if (enabled) {
+      if (Objects.equals(this.ruleIdentity, ruleIdentity)) {
+        return;
+      }
+      // The grouping rule may have changed since we were last enabled. Drop any pending
+      // retry first - it closed over the old group and would otherwise recreate a stale
+      // summary via reconcile() after we cancel it below.
+      retryHandler.removeCallbacksAndMessages(null);
+      cancelAllSummaries();
+      this.ruleIdentity = ruleIdentity;
+      return;
+    }
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      // NotificationManagerCompat#getActiveNotifications() is unsupported before API 23, so
+      // child counts can't be tracked and summaries can't be maintained.
+      return;
+    }
+    enabled = true;
+    this.ruleIdentity = ruleIdentity;
+    createSummaryChannel();
+
+    receivedListener = bundle -> runOnMainThread(() -> onReceived(bundle));
+    clickListener = bundle -> runOnMainThread(() -> onRemoved(bundle));
+    closeListener = bundle -> runOnMainThread(() -> onRemoved(bundle));
+    RetenoNotifications.getReceived().addListener(receivedListener);
+    RetenoNotifications.getClick().addListener(clickListener);
+    RetenoNotifications.getClose().addListener(closeListener);
+  }
+
+  private void disable() {
+    enabled = false;
+    ruleIdentity = null;
+    retryHandler.removeCallbacksAndMessages(null);
+    if (receivedListener != null) {
+      RetenoNotifications.getReceived().removeListener(receivedListener);
+      receivedListener = null;
+    }
+    if (clickListener != null) {
+      RetenoNotifications.getClick().removeListener(clickListener);
+      clickListener = null;
+    }
+    if (closeListener != null) {
+      RetenoNotifications.getClose().removeListener(closeListener);
+      closeListener = null;
+    }
+    cancelAllSummaries();
+  }
+
+  private void createSummaryChannel() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+      // NotificationChannel doesn't exist before API 26.
+      return;
+    }
+    NotificationChannel channel = new NotificationChannel(
+      SUMMARY_CHANNEL_ID,
+      "Grouped notifications summary",
+      NotificationManager.IMPORTANCE_DEFAULT
+    );
+    notificationManager.createNotificationChannel(channel);
+  }
+
+  private void onReceived(Bundle bundle) {
+    String group = resolveGroup(bundle);
+    if (group == null) {
+      return;
+    }
+    awaitChildAndReconcile(group, notificationId(bundle), 0);
+  }
+
+  private void awaitChildAndReconcile(String group, int notificationId, int attempt) {
+    if (!enabled) {
+      return;
+    }
+    if (hasChild(group, notificationId) || attempt >= MAX_POST_ATTEMPTS) {
+      reconcile(group);
+      return;
+    }
+    retryHandler.postDelayed(
+      () -> awaitChildAndReconcile(group, notificationId, attempt + 1),
+      RETRY_DELAY_MS
+    );
+  }
+
+  private void onRemoved(Bundle bundle) {
+    if (!enabled) {
+      return;
+    }
+    String group = resolveGroup(bundle);
+    if (group == null) {
+      return;
+    }
+    awaitRemovalAndReconcile(group, notificationId(bundle), 0);
+  }
+
+  private void awaitRemovalAndReconcile(String group, int notificationId, int attempt) {
+    if (!enabled) {
+      return;
+    }
+    if (hasChild(group, notificationId) && attempt < MAX_REMOVAL_ATTEMPTS) {
+      retryHandler.postDelayed(
+        () -> awaitRemovalAndReconcile(group, notificationId, attempt + 1),
+        RETRY_DELAY_MS
+      );
+      return;
+    }
+    reconcile(group);
+  }
+
+  private String resolveGroup(Bundle bundle) {
+    return RetenoNotificationGroupingRuleProvider.resolveGroup(context, toStringMap(bundle));
+  }
+
+  private Map<String, String> toStringMap(Bundle bundle) {
+    Map<String, String> payload = new HashMap<>();
+    if (bundle == null) {
+      return payload;
+    }
+    for (String key : bundle.keySet()) {
+      Object value = bundle.get(key);
+      payload.put(key, value == null ? null : value.toString());
+    }
+    return payload;
+  }
+
+  private int notificationId(Bundle bundle) {
+    String interactionId = bundle == null ? null : bundle.getString("es_interaction_id");
+    return interactionId == null ? 1 : interactionId.hashCode();
+  }
+
+  private boolean hasChild(String group, int notificationId) {
+    for (StatusBarNotification sbn : notificationManager.getActiveNotifications()) {
+      if (sbn.getId() == notificationId && isChildInGroup(sbn.getNotification(), group)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void reconcile(String group) {
+    if (!enabled) {
+      return;
+    }
+
+    int childCount = 0;
+    for (StatusBarNotification sbn : notificationManager.getActiveNotifications()) {
+      if (isChildInGroup(sbn.getNotification(), group)) {
+        childCount++;
+      }
+    }
+
+    String tag = summaryTag(group);
+    if (childCount < 2) {
+      notificationManager.cancel(tag, SUMMARY_NOTIFICATION_ID);
+      return;
+    }
+    if (ActivityCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS)
+      != PackageManager.PERMISSION_GRANTED) {
+      return;
+    }
+
+    Notification summary = new NotificationCompat.Builder(context, SUMMARY_CHANNEL_ID)
+      .setContentTitle("New notifications")
+      .setContentText("You have " + childCount + " new notifications")
+      .setSmallIcon(resolveSmallIcon())
+      .setGroup(group)
+      .setGroupSummary(true)
+      .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)
+      .setOnlyAlertOnce(true)
+      .build();
+
+    notificationManager.notify(tag, SUMMARY_NOTIFICATION_ID, summary);
+  }
+
+  private int resolveSmallIcon() {
+    int icon = context.getResources().getIdentifier(
+      "reteno_default_push_icon", "drawable", context.getPackageName()
+    );
+    return icon != 0 ? icon : android.R.drawable.ic_dialog_info;
+  }
+
+  private boolean isChildInGroup(Notification notification, String group) {
+    return group.equals(notification.getGroup()) && !NotificationCompat.isGroupSummary(notification);
+  }
+
+  private String summaryTag(String group) {
+    return SUMMARY_TAG_PREFIX + group;
+  }
+
+  private void cancelAllSummaries() {
+    for (StatusBarNotification sbn : notificationManager.getActiveNotifications()) {
+      String tag = sbn.getTag();
+      if (tag != null && tag.startsWith(SUMMARY_TAG_PREFIX)) {
+        notificationManager.cancel(tag, sbn.getId());
+      }
+    }
+  }
+}

--- a/android/src/main/java/com/retenosdk/RetenoSdkModule.java
+++ b/android/src/main/java/com/retenosdk/RetenoSdkModule.java
@@ -1136,7 +1136,7 @@ public void logEcomEventSearchRequest(ReadableMap payload, Promise promise) {
   @ReactMethod
   public void setNotificationGroupingRule(@Nullable ReadableMap rule, Promise promise) {
     if (rule == null) {
-      RetenoNotificationGroupingRuleProvider.configure(context, null, null);
+      RetenoNotificationGroupingRuleProvider.configure(context, null, null, false);
       promise.resolve(true);
       return;
     }
@@ -1160,10 +1160,20 @@ public void logEcomEventSearchRequest(ReadableMap payload, Promise promise) {
       return;
     }
 
+    boolean showSummaryIsBoolean = rule.hasKey("showSummary")
+      && !rule.isNull("showSummary")
+      && rule.getType("showSummary") == ReadableType.Boolean;
+    if (rule.hasKey("showSummary") && !rule.isNull("showSummary") && !showSummaryIsBoolean) {
+      promise.reject("InvalidArgument", "Invalid argument: showSummary must be a boolean");
+      return;
+    }
+    boolean showSummary = showSummaryIsBoolean && rule.getBoolean("showSummary");
+
     RetenoNotificationGroupingRuleProvider.configure(
       context,
       hasPayloadKey ? payloadKey : null,
-      hasGroupId ? groupId : null
+      hasGroupId ? groupId : null,
+      showSummary
     );
     promise.resolve(true);
   }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -89,7 +89,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "1.7.18"
+        versionName "1.7.19"
     }
 
     signingConfigs {

--- a/example/android/app/src/main/java/com/reteno/sample/MainApplication.kt
+++ b/example/android/app/src/main/java/com/reteno/sample/MainApplication.kt
@@ -1,16 +1,6 @@
 package com.reteno.sample
 
-import android.Manifest
 import android.app.Application
-import android.app.NotificationChannel
-import android.app.NotificationManager
-import android.content.pm.PackageManager
-import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
-import androidx.core.app.ActivityCompat
-import androidx.core.app.NotificationCompat
-import androidx.core.app.NotificationManagerCompat
 import com.facebook.react.PackageList
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactHost
@@ -18,22 +8,8 @@ import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 import com.facebook.soloader.SoLoader
 import com.facebook.react.soloader.OpenSourceMergedSoMapping
-import com.reteno.push.RetenoNotifications
-import com.retenosdk.RetenoNotificationGroupingRuleProvider
 
 class MainApplication : Application(), ReactApplication {
-
-  companion object {
-    private const val SUMMARY_CHANNEL_ID = "reteno_demo_group_summary"
-
-    // The "received" event is broadcast on the main thread while the SDK posts the push's own
-    // notification on a background thread — there's no ordering guarantee between the two, and
-    // posting can take longer than usual (e.g. downloading a BigPictureStyle image). A fixed
-    // delay is a heuristic, not a guarantee: if posting is slower than this, the summary is
-    // simply skipped for this push and shown on the next one instead of undercounting silently.
-    // Good enough for a demo; a production integration should not rely on a fixed delay.
-    private const val SUMMARY_CHECK_DELAY_MS = 500L
-  }
 
   override val reactHost: ReactHost by lazy {
     getDefaultReactHost(
@@ -48,52 +24,5 @@ class MainApplication : Application(), ReactApplication {
     if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
       loadReactNative(this)
     }
-    createSummaryNotificationChannel()
-    RetenoNotifications.received.addListener { bundle -> onPushReceivedForGrouping(bundle) }
-  }
-
-  private fun createSummaryNotificationChannel() {
-    val channel = NotificationChannel(
-      SUMMARY_CHANNEL_ID,
-      "Grouped notifications summary",
-      NotificationManager.IMPORTANCE_DEFAULT
-    )
-    NotificationManagerCompat.from(this).createNotificationChannel(channel)
-  }
-
-  private fun onPushReceivedForGrouping(bundle: Bundle) {
-    val payload = bundle.keySet().associateWith { bundle.getString(it) }
-    val group = RetenoNotificationGroupingRuleProvider.resolveGroup(this, payload) ?: return
-    Handler(Looper.getMainLooper()).postDelayed(
-      { showGroupSummaryNotification(group) },
-      SUMMARY_CHECK_DELAY_MS
-    )
-  }
-
-  private fun showGroupSummaryNotification(group: String) {
-    val manager = NotificationManagerCompat.from(this)
-    val groupedCount = manager.activeNotifications.count {
-      it.notification.group == group && !NotificationCompat.isGroupSummary(it.notification)
-    }
-    if (groupedCount < 2) return
-
-    if (ActivityCompat.checkSelfPermission(
-        this,
-        Manifest.permission.POST_NOTIFICATIONS
-      ) != PackageManager.PERMISSION_GRANTED
-    ) return
-
-    val summary = NotificationCompat.Builder(this, SUMMARY_CHANNEL_ID)
-      .setContentTitle("New notifications")
-      .setContentText("You have $groupedCount new notifications")
-      .setSmallIcon(R.mipmap.ic_launcher)
-      .setGroup(group)
-      .setGroupSummary(true)
-      .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)
-      .setOnlyAlertOnce(true)
-      .setAutoCancel(true)
-      .build()
-
-    manager.notify(group.hashCode(), summary)
   }
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2599,7 +2599,7 @@ PODS:
     - React-utils (= 0.83.0)
     - SocketRocket
   - Reteno (2.7.3)
-  - reteno-react-native-sdk (2.2.0):
+  - reteno-react-native-sdk (2.3.0):
     - boost
     - DoubleConversion
     - fast_float

--- a/example/src/screens/pushNotifications.tsx
+++ b/example/src/screens/pushNotifications.tsx
@@ -177,13 +177,17 @@ export default function PushNotificationsScreen() {
         )}
         {Platform.OS === 'android' && (
           <Button
-            onPress={() => handleSetNotificationGroupingRule({ payloadKey: 'chatId' })}
+            onPress={() =>
+              handleSetNotificationGroupingRule({ payloadKey: 'chatId', showSummary: true })
+            }
             label="Group notifications by payload key 'chatId'"
           />
         )}
         {Platform.OS === 'android' && (
           <Button
-            onPress={() => handleSetNotificationGroupingRule({ groupId: 'messages' })}
+            onPress={() =>
+              handleSetNotificationGroupingRule({ groupId: 'messages', showSummary: true })
+            }
             label="Group notifications under constant ID 'messages'"
           />
         )}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reteno-react-native-sdk",
-  "version": "2.1.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reteno-react-native-sdk",
-      "version": "2.1.0",
+      "version": "2.3.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/config-conventional": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reteno-react-native-sdk",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "The Reteno React Native SDK for App Analytics and Engagement.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -68,4 +68,36 @@ describe('setNotificationGroupingRule', () => {
       'Invalid argument: provide exactly one of payloadKey or groupId'
     );
   });
+
+  it('forwards showSummary when true', async () => {
+    await setNotificationGroupingRule({
+      groupId: 'messages',
+      showSummary: true,
+    });
+
+    expect(mockSetNotificationGroupingRule).toHaveBeenCalledWith({
+      groupId: 'messages',
+      showSummary: true,
+    });
+  });
+
+  it('omits showSummary when false', async () => {
+    await setNotificationGroupingRule({
+      groupId: 'messages',
+      showSummary: false,
+    });
+
+    expect(mockSetNotificationGroupingRule).toHaveBeenCalledWith({
+      groupId: 'messages',
+    });
+  });
+
+  it('rejects a non-boolean showSummary value', async () => {
+    await expect(
+      setNotificationGroupingRule({
+        groupId: 'messages',
+        showSummary: 'yes',
+      } as unknown as Parameters<typeof setNotificationGroupingRule>[0])
+    ).rejects.toThrow('Invalid argument: showSummary must be a boolean');
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,10 +148,13 @@ export type NotificationPermissionStatus =
 /**
  * Android notification grouping rule. The rule is stored natively and restored
  * before React Native starts, so it is also applied to background notifications.
+ *
+ * `showSummary` requires Android 6.0 (API 23) or higher. On older versions it is
+ * silently ignored - grouping still applies, but no summary notification is shown.
  */
 export type NotificationGroupingRule =
-  | { payloadKey: string; groupId?: never }
-  | { groupId: string; payloadKey?: never };
+  | { payloadKey: string; groupId?: never; showSummary?: boolean }
+  | { groupId: string; payloadKey?: never; showSummary?: boolean };
 
 export type InAppCustomData = {
   customData?: Record<string, any>;
@@ -891,6 +894,9 @@ export function getNotificationPermissionStatus(): Promise<NotificationPermissio
 /**
  * Android only. Groups notifications by a push payload value or a constant ID.
  * Pass `null` to disable grouping.
+ *
+ * `showSummary` requires Android 6.0 (API 23) or higher; on older versions the
+ * promise still resolves successfully, but no summary notification is created.
  */
 export function setNotificationGroupingRule(
   rule: NotificationGroupingRule | null
@@ -921,10 +927,19 @@ export function setNotificationGroupingRule(
       )
     );
   }
+  if (rule.showSummary !== undefined && typeof rule.showSummary !== 'boolean') {
+    return Promise.reject(
+      new Error('Invalid argument: showSummary must be a boolean')
+    );
+  }
 
-  return RetenoSdk.setNotificationGroupingRule(
-    payloadKey ? { payloadKey } : { groupId }
-  );
+  const normalizedRule: Record<string, unknown> = payloadKey
+    ? { payloadKey }
+    : { groupId };
+  if (rule.showSummary === true) {
+    normalizedRule.showSummary = true;
+  }
+  return RetenoSdk.setNotificationGroupingRule(normalizedRule);
 }
 
 /**


### PR DESCRIPTION
### What's Changed

- Added optional summary notifications for grouped Android push notifications.
- Extended the Android-only `setNotificationGroupingRule` API with the new `showSummary` option.
- Summary notifications automatically reflect the number of active notifications in a group.
- Summaries are updated or removed when grouped notifications are opened or dismissed.
- Grouping configuration and summary settings are restored after an application process restart.
- Added validation to ensure that `showSummary` is a boolean.